### PR TITLE
Add initial position option to Slider.kt

### DIFF
--- a/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
+++ b/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
@@ -32,10 +32,11 @@ private class SliderState(
     private val steps: Int,
     private val thumbWidth: Int,
     private val parentWidth: Int,
+    private val initialPosition: Float,
     private val onStep: (Int) -> Unit,
 ) {
-    var position by mutableStateOf(0f)
-    private var dragPosition = 0f
+    var position by mutableStateOf(initialPosition)
+    private var dragPosition = initialPosition
 
     private fun snapToClosestStep(point: Float): Pair<Float, Int> {
         val stepSize = (parentWidth - thumbWidth) / (steps - 1)
@@ -68,6 +69,7 @@ private fun Modifier.thumbDrag(
 fun Slider(
     modifier: Modifier = Modifier,
     steps: Int = 10,
+    initialPosition: Float = 0f
     onStep: (Int) -> Unit,
 ) {
     require(steps >= 2) { "Number of steps must be 2 or larger" }
@@ -78,7 +80,7 @@ fun Slider(
     val interactionSource = remember { MutableInteractionSource() }
 
     val state = remember(steps, onStep, parentWidth, thumbWidth) {
-        SliderState(steps, thumbWidth, parentWidth, onStep)
+        SliderState(steps, initialPosition, thumbWidth, parentWidth, onStep)
     }
 
     val policy = remember(state) {


### PR DESCRIPTION
Hello! I am working on a companion app for a game I have designed and would love to use this theme.

While making a settings menu, I found that I could not set the slider to have an initial value (It always defaults to the left-most position). I need the value to initially match the setting. This seems like an easy expansion of a default value parameter on the @Compose component. Please let me know if there's anything else I can or should add!