### PR TITLE
Slider default fix

### DIFF
--- a/components-overview/src/commonMain/kotlin/nl/ncaj/theme/win9x/Overview.kt
+++ b/components-overview/src/commonMain/kotlin/nl/ncaj/theme/win9x/Overview.kt
@@ -234,7 +234,11 @@ private fun TextBoxExample() {
 
 @Composable
 private fun SliderExample() {
-    Slider(steps = 4, onStep = { })
+    Column {
+        Slider(steps = 4, onStep = { })
+        Spacer(modifier = Modifier.height(2.dp))
+        Slider(steps = 4, onStep = { }, initialStep = 2)
+    }
 }
 
 @Composable

--- a/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
+++ b/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
@@ -32,10 +32,11 @@ private class SliderState(
     private val steps: Int,
     private val thumbWidth: Int,
     private val parentWidth: Int,
+    private val initialPosition: Float,
     private val onStep: (Int) -> Unit,
 ) {
-    var position by mutableStateOf(0f)
-    private var dragPosition = 0f
+    var position by mutableStateOf(initialPosition)
+    private var dragPosition = initialPosition
 
     private fun snapToClosestStep(point: Float): Pair<Float, Int> {
         val stepSize = (parentWidth - thumbWidth) / (steps - 1)
@@ -68,6 +69,7 @@ private fun Modifier.thumbDrag(
 fun Slider(
     modifier: Modifier = Modifier,
     steps: Int = 10,
+    initialPosition: Float = 0f
     onStep: (Int) -> Unit,
 ) {
     require(steps >= 2) { "Number of steps must be 2 or larger" }
@@ -78,7 +80,7 @@ fun Slider(
     val interactionSource = remember { MutableInteractionSource() }
 
     val state = remember(steps, onStep, parentWidth, thumbWidth) {
-        SliderState(steps, thumbWidth, parentWidth, onStep)
+        SliderState(steps, initialPosition, thumbWidth, parentWidth, onStep)
     }
 
     val policy = remember(state) {

--- a/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
+++ b/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
@@ -30,12 +30,12 @@ import kotlin.math.roundToInt
 @Stable
 private class SliderState(
     private val steps: Int,
+    initialPosition: Float,
     private val thumbWidth: Int,
     private val parentWidth: Int,
-    private val initialPosition: Float,
     private val onStep: (Int) -> Unit,
 ) {
-    var position by mutableStateOf(initialPosition)
+    var position by mutableStateOf(snapToClosestStep(initialPosition).second.toFloat())
     private var dragPosition = initialPosition
 
     private fun snapToClosestStep(point: Float): Pair<Float, Int> {
@@ -69,7 +69,7 @@ private fun Modifier.thumbDrag(
 fun Slider(
     modifier: Modifier = Modifier,
     steps: Int = 10,
-    initialPosition: Float = 0f
+    initialPosition: Float = 0f,
     onStep: (Int) -> Unit,
 ) {
     require(steps >= 2) { "Number of steps must be 2 or larger" }

--- a/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
+++ b/win9x-theme/src/commonMain/kotlin/nl/ncaj/theme/win9x/controls/Slider.kt
@@ -29,17 +29,17 @@ import kotlin.math.roundToInt
 
 @Stable
 private class SliderState(
-    private val steps: Int,
-    initialPosition: Float,
+    steps: Int,
+    initialStep: Int,
     private val thumbWidth: Int,
     private val parentWidth: Int,
     private val onStep: (Int) -> Unit,
 ) {
-    var position by mutableStateOf(snapToClosestStep(initialPosition).second.toFloat())
-    private var dragPosition = initialPosition
+    val stepSize = (parentWidth - thumbWidth) / (steps - 1)
+    var position by mutableStateOf(initialStep.toFloat() * stepSize)
+    private var dragPosition = position
 
     private fun snapToClosestStep(point: Float): Pair<Float, Int> {
-        val stepSize = (parentWidth - thumbWidth) / (steps - 1)
         if (stepSize == 0) return point to 0
         val step = (point / stepSize).roundToInt()
         return (step * stepSize).toFloat() to step
@@ -69,7 +69,7 @@ private fun Modifier.thumbDrag(
 fun Slider(
     modifier: Modifier = Modifier,
     steps: Int = 10,
-    initialPosition: Float = 0f,
+    initialStep: Int = 0,
     onStep: (Int) -> Unit,
 ) {
     require(steps >= 2) { "Number of steps must be 2 or larger" }
@@ -80,7 +80,7 @@ fun Slider(
     val interactionSource = remember { MutableInteractionSource() }
 
     val state = remember(steps, onStep, parentWidth, thumbWidth) {
-        SliderState(steps, initialPosition, thumbWidth, parentWidth, onStep)
+        SliderState(steps, initialStep.coerceIn(0, steps - 1), thumbWidth, parentWidth, onStep)
     }
 
     val policy = remember(state) {


### PR DESCRIPTION
Hello! I am working on a companion app for a game I have designed and would love to use this theme.

While making a settings menu, I found that I could not set the slider to have an initial value (It always defaults to the left-most position). I need the value to initially match the setting. This seems like an easy expansion of a default value parameter on the @Compose component. Please let me know if there's anything else I can or should add!